### PR TITLE
feat: fix ShoppingBag_C_00_02's parent room entity (closes #2)

### DIFF
--- a/content/chunk24/Fix_ShoppingBag_C_00_02_RoomEntityParent.entity.patch.json
+++ b/content/chunk24/Fix_ShoppingBag_C_00_02_RoomEntityParent.entity.patch.json
@@ -1,0 +1,35 @@
+{
+	"tempHash": "00A8D11D59F72B44",
+	"tbluHash": "00C9235B55F84BEE",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"b69c0730104aa95b",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": { "x": 0, "y": 0, "z": 107.00042868507349 },
+							"position": { "x": -0.10269930958747864, "y": -4.537006855010986, "z": -1.1885490715503693 }
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"b69c0730104aa95b",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_eidParent",
+						"value": {
+							"ref": "ef758f8ec48ff8f5",
+							"externalScene": "[assembly:/_pro/scenes/missions/bangkok/location.brick].pc_entitytype"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Reparents ShoppingBag_C_00_02 to the proper room entity so it's no longer invisible in 47's suite
![image](https://github.com/glacier-modding/H3-Community-Patches/assets/43296291/4ebe6658-1c76-48b5-b92e-f07adf43621f)
