### PR TITLE
fix: Restore deleted tracksuit top mesh

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
 	"contentFolders": ["content"],
 	"frameworkVersion": "2.33.7",
 	"updateCheck": "https://github.com/glacier-modding/H3-Community-Patches/releases/latest/download/updates.json",
+	"dependencies": ["00954F2A467328E9"],
 	"localisationOverrides": {
 		"00E8D1F727A21C56": {
 			"english": {


### PR DESCRIPTION
Fixes #16

Civilian in Berlin by the projection bar has an invisible torso mesh. It is in the deletion lists of chunk0patch4, chunk2patch3 and chunk4patch2. It is deleted from all chunks where it's supposed to exist. This will pull it to the chunk0 patch SMF creates.