### PR TITLE
chore: update license to exclude IOI assets

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,3 @@
 All assets under the following paths in this repository are the property of IO Interactive:
 
-- [fill this in in a minute]
+- IOblobs/*

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,3 @@
+All assets under the following paths in this repository are the property of IO Interactive:
+
+- [fill this in in a minute]

--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,5 @@
 All assets under the following paths in this repository are the property of IO Interactive:
 
 - IOblobs/*
+
+The rest of the mod is licensed by LGPL-v3, whose terms are included in COPYING.GPL and COPYING.LESSER

--- a/COPYING.GPL
+++ b/COPYING.GPL
@@ -1,3 +1,10 @@
+All assets under the following paths in this repository are the property of IO Interactive:
+
+- blobs/images/actors
+
+The rest of the mod is licensed by GPL-v3:
+
+
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/COPYING.GPL
+++ b/COPYING.GPL
@@ -1,10 +1,3 @@
-All assets under the following paths in this repository are the property of IO Interactive:
-
-- blobs/images/actors
-
-The rest of the mod is licensed by GPL-v3:
-
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/IOblobs/placeholder.txt
+++ b/IOblobs/placeholder.txt
@@ -1,1 +1,0 @@
-This file exists to make sure that the IOblobs folder isn't deleted automatically. IOblobs isn't used yet, but my next PR (the reason the license needed to be updated) will use it (once I update the PR)

--- a/IOblobs/placeholder.txt
+++ b/IOblobs/placeholder.txt
@@ -1,0 +1,1 @@
+This file exists to make sure that the IOblobs folder isn't deleted automatically. IOblobs isn't used yet, but my next PR (the reason the license needed to be updated) will use it (once I update the PR)

--- a/blobsIOI/placeholder.txt
+++ b/blobsIOI/placeholder.txt
@@ -1,0 +1,1 @@
+This file exists to make sure that the IOblobs folder isn't deleted automatically. IOblobs isn't used yet, but my next PR (the reason the license needed to be updated) will use it (once I update the PR)

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 	"description": "A collection of fixes for Hitman: World of Assassination. This ranges from localisation line break fixes, inverted normals on clothing, and everything in-between. If it's broken in-game, this project aims to fix it!",
 	"authors": ["Notex", "Minnow", "Atampy26", "Jojje", "Dribbleondo", "musicalmushr00m", "VoodooHillbilly", "Cybore"],
 	"contentFolders": ["content/SmallFixes", "content/MovieSetLamp", "content/SapienzaChurch"],
-	"blobsFolders": ["blobs", "IOblobs"],
+	"blobsFolders": ["blobs", "blobsIOI"],
 	"frameworkVersion": "2.33.12",
 	"updateCheck": "https://github.com/glacier-modding/H3-Community-Patches/releases/latest/download/updates.json",
 	"options": [

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 	"description": "A collection of fixes for Hitman: World of Assassination. This ranges from localisation line break fixes, inverted normals on clothing, and everything in-between. If it's broken in-game, this project aims to fix it!",
 	"authors": ["Notex", "Minnow", "Atampy26", "Jojje", "Dribbleondo", "musicalmushr00m", "VoodooHillbilly", "Cybore"],
 	"contentFolders": ["content/SmallFixes", "content/MovieSetLamp", "content/SapienzaChurch"],
-	"blobsFolders": ["blobs"],
+	"blobsFolders": ["blobs", "IOblobs"],
 	"frameworkVersion": "2.33.12",
 	"updateCheck": "https://github.com/glacier-modding/H3-Community-Patches/releases/latest/download/updates.json",
 	"options": [


### PR DESCRIPTION
This will update the license (and, to a lesser extent, the folder structure) to make it more clear what's the property of IO and what was made or edited by this mod's contributors.

Related to #102, which was supposed to be a quick, easy fix... it was not :p