### PR TITLE
feat: make oil puddles appear properly for HAVEN water scooters

### DIFF
--- a/content/SmallFixes/chunk10/WaterScooterFix/setpiece_opulent_trap_waterscooter_a.entity.patch.json
+++ b/content/SmallFixes/chunk10/WaterScooterFix/setpiece_opulent_trap_waterscooter_a.entity.patch.json
@@ -1,0 +1,29 @@
+{
+	"tempHash": "00060EA3F8C0C77C",
+	"tbluHash": "006418A9134AE9E5",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"4d004cecd1e38131",
+				{
+					"SetPropertyValue": {
+						"property_name": "OilSpillTransform",
+						"value": {
+							"rotation": {
+								"x": 0,
+								"y": 0,
+								"z": 0
+							},
+							"position": {
+								"x": 0,
+								"y": -0.2,
+								"z": 0.16
+							}
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
In the unmodded game, oil puddles don't appear properly under sabotaged water scooters. This fixes that.

Made by Cybore on Discord, I'm just making the PR.