### PR TITLE
feat: add various fixes by Cybore

### DIFF
--- a/content/SmallFixes/chunk0/PhoneFixes/explosivephone_loopfix_v2.entity.patch.json
+++ b/content/SmallFixes/chunk0/PhoneFixes/explosivephone_loopfix_v2.entity.patch.json
@@ -1,0 +1,54 @@
+{
+	"tempHash": "00C125F564ACE981",
+	"tbluHash": "00FCACE39B79DD4E",
+	"patch": [
+		{ "SubEntityOperation": ["87fc9cdd0335ced4", { "AddEventConnection": ["OnTriggered", "In", "feed238f94445405"] }] },
+		{
+			"AddEntity": [
+				"feed432be58c8916",
+				{
+					"parent": "87fc9cdd0335ced4",
+					"name": "SetPosition",
+					"factory": "[modules:/zsetpositionentity.class].pc_entitytype",
+					"blueprint": "[modules:/zsetpositionentity.class].pc_entityblueprint",
+					"properties": {
+						"m_Reference": { "type": "SEntityTemplateReference", "value": "feed6269607acea6" },
+						"m_Entity": { "type": "SEntityTemplateReference", "value": "18d7b10e7790e943", "postInit": true }
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"feed6269607acea6",
+				{
+					"parent": "feed432be58c8916",
+					"name": "Offset",
+					"factory": "[modules:/zcompositeentity.class].pc_entitytype",
+					"blueprint": "[modules:/zcompositeentity.class].pc_entityblueprint",
+					"properties": {
+						"m_mTransform": {
+							"type": "SMatrix43",
+							"value": { "rotation": { "x": 0, "y": 0, "z": 0 }, "position": { "x": 0, "y": -2000, "z": 0 } }
+						},
+						"m_eidParent": { "type": "SEntityTemplateReference", "value": "18d7b10e7790e943", "postInit": true }
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"feed238f94445405",
+				{
+					"parent": "87fc9cdd0335ced4",
+					"name": "Timer Delay On",
+					"factory": "[assembly:/_pro/design/logic.template?/timersimple.entitytemplate].pc_entitytype",
+					"blueprint": "[assembly:/_pro/design/logic.template?/timersimple.entitytemplate].pc_entityblueprint",
+					"properties": { "Delay time (ms)": { "type": "int32", "value": 2000 } },
+					"events": { "Out": { "SetPosition": ["feed432be58c8916"] } }
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk0/PhoneFixes/flashphone_loopfix_v2.entity.patch.json
+++ b/content/SmallFixes/chunk0/PhoneFixes/flashphone_loopfix_v2.entity.patch.json
@@ -1,0 +1,54 @@
+{
+	"tempHash": "00C64F68AEB0621D",
+	"tbluHash": "0092D761C88E261E",
+	"patch": [
+		{ "SubEntityOperation": ["cb5551ec1ab9b3ae", { "AddEventConnection": ["Triggered", "In", "feed54b7c8e2c0b0"] }] },
+		{
+			"AddEntity": [
+				"feedadfb03cec675",
+				{
+					"parent": "cb5551ec1ab9b3ae",
+					"name": "SetPosition",
+					"factory": "[modules:/zsetpositionentity.class].pc_entitytype",
+					"blueprint": "[modules:/zsetpositionentity.class].pc_entityblueprint",
+					"properties": {
+						"m_Reference": { "type": "SEntityTemplateReference", "value": "feed6ba478e4baae" },
+						"m_Entity": { "type": "SEntityTemplateReference", "value": "07bc984e8810f79a", "postInit": true }
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"feed6ba478e4baae",
+				{
+					"parent": "feedadfb03cec675",
+					"name": "Offset",
+					"factory": "[modules:/zcompositeentity.class].pc_entitytype",
+					"blueprint": "[modules:/zcompositeentity.class].pc_entityblueprint",
+					"properties": {
+						"m_mTransform": {
+							"type": "SMatrix43",
+							"value": { "rotation": { "x": 0, "y": 0, "z": 0 }, "position": { "x": 0, "y": -2000, "z": 0 } }
+						},
+						"m_eidParent": { "type": "SEntityTemplateReference", "value": "07bc984e8810f79a", "postInit": true }
+					}
+				}
+			]
+		},
+		{
+			"AddEntity": [
+				"feed54b7c8e2c0b0",
+				{
+					"parent": "cb5551ec1ab9b3ae",
+					"name": "Timer Delay On",
+					"factory": "[assembly:/_pro/design/logic.template?/timersimple.entitytemplate].pc_entitytype",
+					"blueprint": "[assembly:/_pro/design/logic.template?/timersimple.entitytemplate].pc_entityblueprint",
+					"properties": { "Delay time (ms)": { "type": "int32", "value": 2000 } },
+					"events": { "Out": { "SetPosition": ["feedadfb03cec675"] } }
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk18/SubSuspicionFix/colombia_sub.entity.patch.json
+++ b/content/SmallFixes/chunk18/SubSuspicionFix/colombia_sub.entity.patch.json
@@ -1,0 +1,8 @@
+{
+	"tempHash": "00887DDFD8656D90",
+	"tbluHash": "00FA83E7FF633C2E",
+	"patch": [
+		{ "SubEntityOperation": ["1101ae83e206dba0", { "AddEventConnection": ["OnDead", "Disable", "e7edad6c260b8b38"] }] }
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk19/SugarEndsRace/sugar.entity.patch.json
+++ b/content/SmallFixes/chunk19/SugarEndsRace/sugar.entity.patch.json
@@ -1,0 +1,31 @@
+{
+	"tempHash": "0056406088754691",
+	"tbluHash": "00CF14C55C3BCCA8",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"9bf87d4396e3ad1a",
+				{
+					"AddEventConnection": ["SierraOutOfCar", "In", "67ef5d5ae239dfba"]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"9bf87d4396e3ad1a",
+				{
+					"AddEventConnection": ["MosesGetOutSugarCutScene", "disableTimer", "3b92478ce2999017"]
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"9bf87d4396e3ad1a",
+				{
+					"AddEventConnection": ["SierraGetOutSugarCutScene", "disableTimer", "3b92478ce2999017"]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
This adds the following fixes made by Cybore on Discord:

- Guards will no longer open fire on 47 when leaving the submarine platform after Rico dies during the related Mission Story. They will still open fire if Rico is alive and 47-as-Engineer abandons his job, as intended. (fixes #108)
- The Flash & Electrocution phones will no longer leave behind "phantom" phones that get NPCs stuck in an infinite loop of trying to pick up something that isn't there (fixes #61)
- After sabotaging Sierra Knox or Moses Lee by pouring sugar in their fuel tank, the race will now end properly. (fixes #109)