### PR TITLE
fix: update manifest.json to properly include Luiluix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
 		"musicalmushr00m",
 		"VoodooHillbilly",
 		"Cybore",
-		"Anthony Fuller"
+		"Anthony Fuller",
+		"Luiluix"
 	],
 	"contentFolders": ["content/SmallFixes", "content/MovieSetLamp", "content/SapienzaChurch"],
 	"blobsFolders": ["blobs", "blobsIOI"],


### PR DESCRIPTION
Somehow, Luiluix has gone uncredited for a while. That's not right!