### PR TITLE
feat: fix 2 coverplanes on sniper building rooftop in Chongqing

### DIFF
--- a/content/SmallFixes/chunk6/RatAgility/scenario_rat.entity.patch.json
+++ b/content/SmallFixes/chunk6/RatAgility/scenario_rat.entity.patch.json
@@ -1,0 +1,28 @@
+{
+	"tempHash": "0005C60C0B3C7977",
+	"tbluHash": "002E69256922F8F6",
+	"patch": [
+		{ "RemoveEntityByID": "cf26bf33d47bc021" },
+		{
+			"SubEntityOperation": [
+				"7ab61fc1f1b2841c",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_mTransform",
+						"value": {
+							"rotation": { "x": -0.0, "y": 0.0, "z": -90.52225852693535 },
+							"position": { "x": -104.2938003540039, "y": 114.333, "z": 113.29309844970703 }
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"7ab61fc1f1b2841c",
+				{ "SetPropertyValue": { "property_name": "m_fCoverLength", "value": 4.4 } }
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Fixes these 2 coverplanes that clip into props on the sniper building rooftop in Chongqing:
![image](https://github.com/glacier-modding/H3-Community-Patches/assets/43296291/ffca4ddf-7df0-449c-9d7c-4cc0b98d227b)

![image-1](https://github.com/glacier-modding/H3-Community-Patches/assets/43296291/905e893c-567e-489f-a532-4597309da3bb)
