### PR TITLE
fix: change manifest to load before Freelancer Variations

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
 		"content/SecurityCams",
 		"content/OACFixes"
 	],
+	"loadBefore": ["KevinRudd.FreelancerVariations"],
 	"blobsFolders": ["blobs", "blobsIOI"],
 	"frameworkVersion": "2.33.18",
 	"updateCheck": "https://github.com/glacier-modding/H3-Community-Patches/releases/latest/download/updates.json",


### PR DESCRIPTION
This should solve a load order conflict, hopefully.