### PR TITLE
feat: fix Dubai exits for Freelancer Leaders being broken when trying to evacuate during Showdowns

### DIFF
--- a/content/SmallFixes/chunk0/FreelancerDubaiEscapeFix/mission_hot_chess.entity.patch.json
+++ b/content/SmallFixes/chunk0/FreelancerDubaiEscapeFix/mission_hot_chess.entity.patch.json
@@ -1,0 +1,139 @@
+{
+	"tempHash": "0003DE78FA9807D5",
+	"tbluHash": "001E37B3A3CEDF6E",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"f6104aa898016cef",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"e016f5d80ed9bfbe",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"54fafa5da59fe711",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"a68574767b4060f2",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"22195eb4429a6e31",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"d1de83b10956ae2d",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"c1f167ddf4257154",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"2d0bd6fcbfd44232",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"880d2e52d489c423",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"b0a72324f527bd7c",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"7692ad43f844df8e",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"d583c0fece4ad106",
+				{
+					"SetPropertyValue": {
+						"property_name": "numberOfExits",
+						"value": 2
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
This was made by team ruddcy.

In vanilla, about 50% of leaders will fail to evacuate due to a bug. Instead, they'll just stand there panicking and trying to evacuate, but they can't because their exit is broken.