### PR TITLE
feat: add LOD property to canopy from backdrop building H

### DIFF
--- a/content/SmallFixes/chunk27/CanopyLOD/Canopy_Shop_B_Up_4m_00_02.entity.patch.json
+++ b/content/SmallFixes/chunk27/CanopyLOD/Canopy_Shop_B_Up_4m_00_02.entity.patch.json
@@ -1,0 +1,18 @@
+{
+	"tempHash": "00706C5A3502C158",
+	"tbluHash": "00BAE5C644049402",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"6352be5645f8b75c",
+				{
+					"AddProperty": [
+						"m_fLODScale",
+						{ "type": "float32", "value": 4.0 }
+					]
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
Adds a LOD property used by other canopies on other backdrop buildings so that the model does not disappear when viewed from within the level boundaries

![HITMAN3_6Fa0NVzpaW](https://github.com/user-attachments/assets/abda9ce0-1e55-45a1-9666-b2bfff4af00e)