### PR TITLE
feat: rename Ambrose Control Unit Access Card map labels

### DIFF
--- a/content/SmallFixes/chunk0/AmbroseAccessCardMapLabels/dugong_mcguffinkey_a.entity.patch.json
+++ b/content/SmallFixes/chunk0/AmbroseAccessCardMapLabels/dugong_mcguffinkey_a.entity.patch.json
@@ -1,0 +1,49 @@
+{
+	"tempHash": "001D37E88549C054",
+	"tbluHash": "00112A70F480F5E0",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"ff2a80aa835cc42c",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pHeader",
+						"value": {
+							"resource": "0048852E811DBC98",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"ff2a80aa835cc42c",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pTitle",
+						"value": {
+							"resource": "0048852E811DBC98",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"ff2a80aa835cc42c",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pDescription",
+						"value": {
+							"resource": "00621F325DDFB06D",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}

--- a/content/SmallFixes/chunk0/AmbroseAccessCardMapLabels/dugong_mcguffinkey_b.entity.patch.json
+++ b/content/SmallFixes/chunk0/AmbroseAccessCardMapLabels/dugong_mcguffinkey_b.entity.patch.json
@@ -1,0 +1,49 @@
+{
+	"tempHash": "00F725F3734C5B6D",
+	"tbluHash": "0039532443F04DB7",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"ce3afa6f950b351a",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pHeader",
+						"value": {
+							"resource": "00D0910FFB2E96D1",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"ce3afa6f950b351a",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pTitle",
+						"value": {
+							"resource": "00D0910FFB2E96D1",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"ce3afa6f950b351a",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_pDescription",
+						"value": {
+							"resource": "003FBB953D5B071B",
+							"flag": "5F"
+						}
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
The cards were incorrectly labeled "Backup Data Disk" on the map. They are now correctly labeled Control Unit Access Card A and Control Unit Access Card B.