### PR TITLE
feat: adjusted the lanterns in Hokkaido to spawn the same amount as in 2016

### DIFF
--- a/content/SmallFixes/chunk22/outside_lanterns_total_fix/hokkaido_lantern_spawns.entity.patch.json
+++ b/content/SmallFixes/chunk22/outside_lanterns_total_fix/hokkaido_lantern_spawns.entity.patch.json
@@ -1,0 +1,29 @@
+{
+	"tempHash": "00DC179DAB61D86D",
+	"tbluHash": "00FB4EFEB6BCC8AD",
+	"patch": [
+		{
+			"SubEntityOperation": [
+				"26e67861f9d95c53",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fParticlesPerSecond",
+						"value": -0.0
+					}
+				}
+			]
+		},
+		{
+			"SubEntityOperation": [
+				"a110d3ba10beb54a",
+				{
+					"SetPropertyValue": {
+						"property_name": "m_fParticlesPerSecond",
+						"value": 0.0
+					}
+				}
+			]
+		}
+	],
+	"patchVersion": 6
+}


### PR DESCRIPTION
The particle system in H3 seems to been altered, making the lanterns spawn less in 2016.

this fixes #181